### PR TITLE
Infra/event context shorter

### DIFF
--- a/Source/Application/AnalyticsTracking/TrackableEvent.swift
+++ b/Source/Application/AnalyticsTracking/TrackableEvent.swift
@@ -14,13 +14,6 @@ protocol TrackableEvent {
     var eventContext: String { get }
 }
 
-// MARK: Default Implementation of `enum SomeEnum: String`
-extension TrackableEvent where Self: RawRepresentable, Self.RawValue == String {
-    var eventName: String {
-        return rawValue
-    }
-}
-
 // MARK: Default Implemtation for `enum` that do not have RawTypes, using reflection
 extension TrackableEvent {
     var eventName: String {

--- a/Source/Application/AnalyticsTracking/TrackableEvent.swift
+++ b/Source/Application/AnalyticsTracking/TrackableEvent.swift
@@ -11,6 +11,7 @@ import Foundation
 /// Trackable event, most likely user interaction, i.e, button tap.
 protocol TrackableEvent {
     var eventName: String { get }
+    var eventContext: String { get }
 }
 
 // MARK: Default Implementation of `enum SomeEnum: String`
@@ -29,6 +30,10 @@ extension TrackableEvent {
         } else {
             incorrectImplementation("You need to conform to `TrackableEvent`")
         }
+    }
+
+    var eventContext: String {
+        return String(describing: type(of: self))
     }
 }
 

--- a/Source/Application/AnalyticsTracking/TrackedUserAction.swift
+++ b/Source/Application/AnalyticsTracking/TrackedUserAction.swift
@@ -8,5 +8,14 @@
 
 import Foundation
 
-/// A trackable event that was directly or indirectly initiated by the user
+/// A trackable event that was directly or indirectly initiated by the user.
+/// You should probably make this an enum. And you _SHOULD_ name the cases
+/// like they where prefix with the words "user did".
+///
+/// Example:
+/// For `ChoosePincodeUserAction` we have the the two cases:
+///   * skip
+///   * chosePincode
+/// Which should read out like "user did skip" and "user did chose pincode"
+/// respectively.
 protocol TrackedUserAction: TrackableEvent {}

--- a/Source/Application/AnalyticsTracking/Tracker.swift
+++ b/Source/Application/AnalyticsTracking/Tracker.swift
@@ -21,10 +21,7 @@ struct Tracker {
 // MARK: - Tracking
 extension Tracker: Tracking {
     func track(event: TrackableEvent) {
-        let eventName = "event: '\(event.eventName)'"
-        guard preferences.isTrue(.hasAcceptedAnalyticsTracking) else {
-            return log.verbose("User haven't accepted analytics tracker, omitting \(eventName)")
-        }
-        log.verbose("tracked \(eventName) 🌍")
+        guard preferences.isTrue(.hasAcceptedAnalyticsTracking) else { return }
+        log.verbose("🌍 Tracked: \(event.eventContext):\(event.eventName)")
     }
 }

--- a/Source/Scenes/Main/Receive/Receive/ReceiveViewModel.swift
+++ b/Source/Scenes/Main/Receive/Receive/ReceiveViewModel.swift
@@ -13,14 +13,14 @@ import Zesame
 
 private typealias € = L10n.Scene.Receive
 
-// MARK: - ReceiveNavigation
-enum ReceiveNavigation: TrackedUserAction {
-    case userWouldLikeToReceive(transaction: Transaction)
+// MARK: - ReceiveUserAction
+enum ReceiveUserAction: TrackedUserAction {
+    case requestTransaction(Transaction)
 }
 
 // MARK: - ReceiveViewModel
 final class ReceiveViewModel: BaseViewModel<
-    ReceiveNavigation,
+    ReceiveUserAction,
     ReceiveViewModel.InputFromView,
     ReceiveViewModel.Output
 > {
@@ -35,6 +35,9 @@ final class ReceiveViewModel: BaseViewModel<
 
     // swiftlint:disable:next function_body_length
     override func transform(input: Input) -> Output {
+        func userDid(_ userAction: Step) {
+            stepper.step(userAction)
+        }
 
         let wallet = useCase.wallet.filterNil().asDriverOnErrorReturnEmpty()
 
@@ -60,9 +63,8 @@ final class ReceiveViewModel: BaseViewModel<
                 }).drive(),
 
             input.fromController.rightBarButtonTrigger.withLatestFrom(transactionToReceive)
-                .do(onNext: { [unowned stepper] in
-                    stepper.step(.userWouldLikeToReceive(transaction: $0))
-            }).drive()
+                .do(onNext: { userDid(.requestTransaction($0)) })
+                .drive()
         ]
 
         return Output(

--- a/Source/Scenes/Main/Receive/ReceiveCoordinator.swift
+++ b/Source/Scenes/Main/Receive/ReceiveCoordinator.swift
@@ -32,9 +32,9 @@ final class ReceiveCoordinator: AbstractCoordinator<ReceiveCoordinator.Step> {
 private extension ReceiveCoordinator {
 
     func toReceive() {
-        present(type: Receive.self, viewModel: ReceiveViewModel(useCase: useCase)) { [unowned self] in
-            switch $0 {
-            case .userWouldLikeToReceive(let transactionToReceive): self.share(transaction: transactionToReceive)
+        present(type: Receive.self, viewModel: ReceiveViewModel(useCase: useCase)) { [unowned self] userDid in
+            switch userDid {
+            case .requestTransaction(let requestedTransaction): self.share(transaction: requestedTransaction)
             }
         }
     }

--- a/Source/Scenes/Main/Send/SendCoordinator.swift
+++ b/Source/Scenes/Main/Send/SendCoordinator.swift
@@ -51,10 +51,10 @@ private extension SendCoordinator {
             deepLinkedTransaction: deepLinkTransactionSubject.asObservable()
         )
 
-        present(type: Send.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userInitiatedTransaction: break
-            case .userSelectedSeeTransactionDetailsInBrowser(let transactionId): self.openBrowser(viewTxDetailsFor: transactionId)
+        present(type: Send.self, viewModel: viewModel) { [unowned self] userIntendsTo in
+            switch userIntendsTo {
+            case .send: break
+            case .seeTransactionDetailsInBrowser(let transactionId): self.openBrowser(viewTxDetailsFor: transactionId)
 
             }
         }

--- a/Source/Scenes/Main/Settings/Settings/SettingsViewModel.swift
+++ b/Source/Scenes/Main/Settings/Settings/SettingsViewModel.swift
@@ -11,11 +11,11 @@ import RxSwift
 import RxCocoa
 
 // MARK: SettingsNavigation
-enum SettingsNavigation: String, TrackedUserAction {
-    case userSelectedSetPincode
-    case userSelectedRemovePincode
-    case userSelectedBackupWallet
-    case userSelectedRemoveWallet
+enum SettingsNavigation: TrackedUserAction {
+    case setPincode
+    case removePincode
+    case backupWallet
+    case removeWallet
 }
 
 // MARK: SettingsViewModel
@@ -33,6 +33,9 @@ final class SettingsViewModel: BaseViewModel<
 
     // swiftlint:disable:next function_body_length
     override func transform(input: Input) -> Output {
+        func userIntends(to intention: Step) {
+            stepper.step(intention)
+        }
 
         let isRemovePincodeButtonEnabled = input.fromController.viewWillAppear.map { [unowned self] in
             self.useCase.hasConfiguredPincode
@@ -43,24 +46,20 @@ final class SettingsViewModel: BaseViewModel<
         let fromView = input.fromView
         bag <~ [
             fromView.setPincodeTrigger
-                .do(onNext: { [unowned stepper] in
-                    stepper.step(.userSelectedSetPincode)
-                }).drive(),
+                .do(onNext: { userIntends(to: .setPincode) })
+                .drive(),
 
             fromView.removePincodeTrigger
-                .do(onNext: { [unowned stepper] in
-                    stepper.step(.userSelectedRemovePincode)
-                }).drive(),
+                .do(onNext: { userIntends(to: .removePincode) })
+                .drive(),
 
             fromView.backupWalletTrigger
-                .do(onNext: { [unowned stepper] in
-                    stepper.step(.userSelectedBackupWallet)
-                }).drive(),
+                .do(onNext: { userIntends(to: .backupWallet) })
+                .drive(),
 
             fromView.removeWalletTrigger
-                .do(onNext: { [unowned stepper] in
-                    stepper.step(.userSelectedRemoveWallet)
-                }).drive()
+                .do(onNext: { userIntends(to: .removeWallet) })
+                .drive()
         ]
 
         let appVersion = Driver<String?>.just(appVersionString).filterNil()

--- a/Source/Scenes/Main/Settings/SettingsCoordinator.swift
+++ b/Source/Scenes/Main/Settings/SettingsCoordinator.swift
@@ -35,6 +35,26 @@ final class SettingsCoordinator: AbstractCoordinator<SettingsCoordinator.Step> {
 // MARK: - Navigate
 private extension SettingsCoordinator {
 
+    func toSettings() {
+        let viewModel = SettingsViewModel(useCase: pincodeUseCase)
+        present(type: Settings.self, viewModel: viewModel) { [unowned self] userIntendsTo in
+            switch userIntendsTo {
+            case .setPincode: self.toSetPincode()
+            case .removePincode: self.toRemovePincode()
+            case .backupWallet: self.toBackupWallet()
+            case .removeWallet: self.toChooseWallet()
+            }
+        }
+    }
+
+    func toSetPincode() {
+        stepper.step(.userWantsToSetPincode)
+    }
+
+    func toRemovePincode() {
+        stepper.step(.userWantsToRemovePincode)
+    }
+
     func toChooseWallet() {
         walletUseCase.deleteWallet()
         pincodeUseCase.deletePincode()
@@ -43,23 +63,13 @@ private extension SettingsCoordinator {
 
     func toBackupWallet() {
         let viewModel = BackupWalletViewModel(useCase: walletUseCase)
-        present(type: BackupWallet.self, viewModel: viewModel, presentation: .animatedPresent) { [unowned self] in
-            switch $0 {
-            case .userSelectedBackupIsDone: self.presenter?.dismiss(animated: true, completion: nil)
+        present(type: BackupWallet.self, viewModel: viewModel, presentation: .animatedPresent) { [unowned self] userDid in
+            switch userDid {
+            case .backupWallet: self.presenter?.dismiss(animated: true, completion: nil)
             }
         }
     }
 
-    func toSettings() {
-        let viewModel = SettingsViewModel(useCase: pincodeUseCase)
-        present(type: Settings.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userSelectedSetPincode: self.stepper.step(.userWantsToSetPincode)
-            case .userSelectedRemovePincode: self.stepper.step(.userWantsToRemovePincode)
-            case .userSelectedBackupWallet: self.toBackupWallet()
-            case .userSelectedRemoveWallet: self.toChooseWallet()
-            }
-        }
-    }
+
 
 }

--- a/Source/Scenes/Onboarding/0_TermsOfService/TermsOfServiceViewModel.swift
+++ b/Source/Scenes/Onboarding/0_TermsOfService/TermsOfServiceViewModel.swift
@@ -11,8 +11,8 @@ import RxSwift
 import RxCocoa
 
 // MARK: TermsOfServiceNavigation
-enum TermsOfServiceNavigation: String, TrackedUserAction {
-    case userAcceptedTerms
+enum TermsOfServiceNavigation: TrackedUserAction {
+    case acceptTermsOfService
 }
 
 // MARK: - TermsOfServiceViewModel
@@ -29,15 +29,16 @@ final class TermsOfServiceViewModel: BaseViewModel<
     }
     
     override func transform(input: Input) -> Output {
+        func userDid(_ userAction: Step) {
+            stepper.step(userAction)
+        }
 
-        let fromView = input.fromView
-
-        let isAcceptButtonEnabled = fromView.didScrollToBottom.map { true }
+        let isAcceptButtonEnabled = input.fromView.didScrollToBottom.map { true }
 
         bag <~ [
-            fromView.didAcceptTerms.do(onNext: { [unowned self] in
+            input.fromView.didAcceptTerms.do(onNext: { [unowned self] in
                 self.useCase.didAcceptTermsOfService()
-                self.stepper.step(.userAcceptedTerms)
+                userDid(.acceptTermsOfService)
             }).drive()
         ]
 

--- a/Source/Scenes/Onboarding/1_WarningERC20/WarningERC20ViewModel.swift
+++ b/Source/Scenes/Onboarding/1_WarningERC20/WarningERC20ViewModel.swift
@@ -10,14 +10,14 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-// MARK: - WarningERC20Navigation
-enum WarningERC20Navigation: String, TrackedUserAction {
-    case userSelectedRisksAreUnderstood
+// MARK: - WarningERC20UserAction
+enum WarningERC20UserAction: TrackedUserAction {
+    case understandRisks
 }
 
 // MARK: - WarningERC20ViewModel
 final class WarningERC20ViewModel: BaseViewModel<
-    WarningERC20Navigation,
+    WarningERC20UserAction,
     WarningERC20ViewModel.InputFromView,
     WarningERC20ViewModel.Output
 > {
@@ -29,16 +29,18 @@ final class WarningERC20ViewModel: BaseViewModel<
     }
 
     override func transform(input: Input) -> Output {
+        let understandsRisks = Driver.merge(input.fromView.accept, input.fromView.doNotShowAgain)
+
         bag <~ [
-            input.fromView.accept.do(onNext: { [unowned stepper] in
-                stepper.step(.userSelectedRisksAreUnderstood)
+            understandsRisks.do(onNext: { [unowned stepper] in
+                stepper.step(.understandRisks)
             }).drive(),
 
             input.fromView.doNotShowAgain.do(onNext: { [unowned self] in
                 self.useCase.doNotShowERC20WarningAgain()
-                self.stepper.step(.userSelectedRisksAreUnderstood)
             }).drive()
         ]
+        
         return Output()
     }
 }

--- a/Source/Scenes/Onboarding/2_ChooseWallet/0_ChooseWallet/ChooseWalletView.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/0_ChooseWallet/ChooseWalletView.swift
@@ -27,8 +27,8 @@ extension ChooseWalletView: ViewModelled {
     typealias ViewModel = ChooseWalletViewModel
     var inputFromView: InputFromView {
         return InputFromView(
-            createNewTrigger: createNewWalletButton.rx.tap.asDriver(),
-            restoreTrigger: restoreWalletButton.rx.tap.asDriver()
+            createNewWalletTrigger: createNewWalletButton.rx.tap.asDriver(),
+            restoreWalletTrigger: restoreWalletButton.rx.tap.asDriver()
         )
     }
 }

--- a/Source/Scenes/Onboarding/2_ChooseWallet/0_ChooseWallet/ChooseWalletViewModel.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/0_ChooseWallet/ChooseWalletViewModel.swift
@@ -9,30 +9,32 @@
 import RxSwift
 import RxCocoa
 
-// MARK: - ChooseWalletNavigation
-enum ChooseWalletNavigation: String, TrackedUserAction {
-    case userSelectedCreateNewWallet
-    case userSelectedRestoreWallet
+// MARK: - ChooseWalletUserAction
+enum ChooseWalletUserAction: TrackedUserAction {
+    case createNewWallet
+    case restoreWallet
 }
 
 // MARK: - ChooseWalletViewModel
 final class ChooseWalletViewModel: BaseViewModel<
-    ChooseWalletNavigation,
+    ChooseWalletUserAction,
     ChooseWalletViewModel.InputFromView,
     ChooseWalletViewModel.Output
 > {
 
     override func transform(input: Input) -> Output {
-        let fromView = input.fromView
+        func userIntends(to intention: Step) {
+            stepper.step(intention)
+        }
 
         bag <~ [
-            fromView.createNewTrigger.do(onNext: { [unowned stepper] in
-                stepper.step(.userSelectedCreateNewWallet)
-            }).drive(),
+            input.fromView.createNewWalletTrigger
+                .do(onNext: { userIntends(to: .createNewWallet) })
+                .drive(),
 
-            fromView.restoreTrigger.do(onNext: { [unowned stepper] in
-                stepper.step(.userSelectedRestoreWallet)
-            }).drive()
+            input.fromView.restoreWalletTrigger
+                .do(onNext: { userIntends(to: .restoreWallet) })
+                .drive()
         ]
         return Output()
     }
@@ -41,8 +43,8 @@ final class ChooseWalletViewModel: BaseViewModel<
 extension ChooseWalletViewModel {
 
     struct InputFromView {
-        let createNewTrigger: Driver<Void>
-        let restoreTrigger: Driver<Void>
+        let createNewWalletTrigger: Driver<Void>
+        let restoreWalletTrigger: Driver<Void>
     }
 
     struct Output {}

--- a/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/0_CreateNew/CreateNewWalletViewModel.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/0_CreateNew/CreateNewWalletViewModel.swift
@@ -13,15 +13,15 @@ import Zesame
 
 private typealias € = L10n.Scene.CreateNewWallet
 
-// MARK: - CreateNewWalletNavigator
-enum CreateNewWalletNavigator: TrackedUserAction {
-     case userInitiatedCreationOfWallet(Wallet)
+// MARK: - CreateNewWalletUserAction
+enum CreateNewWalletUserAction: TrackedUserAction {
+     case createWallet(Wallet)
 }
 
 // MARK: - CreateNewWalletViewModel
 final class CreateNewWalletViewModel:
 BaseViewModel<
-    CreateNewWalletNavigator,
+    CreateNewWalletUserAction,
     CreateNewWalletViewModel.InputFromView,
     CreateNewWalletViewModel.Output
 > {
@@ -51,7 +51,7 @@ BaseViewModel<
                 self.useCase.createNewWallet(encryptionPassphrase: $0)
                     .asDriverOnErrorReturnEmpty()
             }
-            .do(onNext: { [unowned stepper] in stepper.step(.userInitiatedCreationOfWallet($0)) })
+            .do(onNext: { [unowned stepper] in stepper.step(.createWallet($0)) })
             .drive()
             .disposed(by: bag)
 

--- a/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/1_Backup/BackupWalletViewModel.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/1_Backup/BackupWalletViewModel.swift
@@ -13,14 +13,14 @@ import Zesame
 
 private typealias € = L10n.Scene.BackupWallet
 
-// MARK: - BackupWalletNavigation
-enum BackupWalletNavigation: TrackedUserAction {
-    case userSelectedBackupIsDone(wallet: Wallet)
+// MARK: - BackupWalletUserAction
+enum BackupWalletUserAction: TrackedUserAction {
+    case backupWallet(Wallet)
 }
 
 // MARK: - BackupWalletViewModel
 final class BackupWalletViewModel: BaseViewModel<
-    BackupWalletNavigation,
+    BackupWalletUserAction,
     BackupWalletViewModel.InputFromView,
     BackupWalletViewModel.Output
 > {
@@ -54,7 +54,7 @@ final class BackupWalletViewModel: BaseViewModel<
             input.fromView.doneTrigger.withLatestFrom(understandsRisks)
                 .filter { $0 }
                 .withLatestFrom(wallet)
-                .do(onNext: { [unowned stepper] in stepper.step(.userSelectedBackupIsDone(wallet: $0)) })
+                .do(onNext: { [unowned stepper] in stepper.step(.backupWallet($0)) })
                 .drive()
         ]
 

--- a/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/CreateNewWalletCoordinator.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/1a_CreateNewWallet/CreateNewWalletCoordinator.swift
@@ -42,9 +42,9 @@ private extension CreateNewWalletCoordinator {
 
     func toBackupWallet(wallet: Wallet) {
         let viewModel = BackupWalletViewModel(useCase: walletUseCase)
-        present(type: BackupWallet.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userSelectedBackupIsDone(let wallet): self.toMain(wallet: wallet)
+        present(type: BackupWallet.self, viewModel: viewModel) { [unowned self] userDid in
+            switch userDid {
+            case .backupWallet(let wallet): self.toMain(wallet: wallet)
             }
         }
     }
@@ -53,9 +53,9 @@ private extension CreateNewWalletCoordinator {
         present(
             type: CreateNewWallet.self,
             viewModel: CreateNewWalletViewModel(useCase: walletUseCase)
-        ) { [unowned self] in
-            switch $0 {
-            case .userInitiatedCreationOfWallet(let wallet): self.toBackupWallet(wallet: wallet)
+        ) { [unowned self] userDid in
+            switch userDid {
+            case .createWallet(let wallet): self.toBackupWallet(wallet: wallet)
             }
         }
     }

--- a/Source/Scenes/Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletCoordinator.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletCoordinator.swift
@@ -34,9 +34,9 @@ private extension RestoreWalletCoordinator {
     }
 
     func toRestoreWallet() {
-        present(type: RestoreWallet.self, viewModel: RestoreWalletViewModel(useCase: useCase)) { [unowned self] in
-            switch $0 {
-            case .userInitiatedRestorationOfWallet(let wallet): self.toMain(restoredWallet: wallet)
+        present(type: RestoreWallet.self, viewModel: RestoreWalletViewModel(useCase: useCase)) { [unowned self] userIntendsTo in
+            switch userIntendsTo {
+            case .restoreWallet(let wallet): self.toMain(restoredWallet: wallet)
             }
         }
     }

--- a/Source/Scenes/Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletViewModel.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletViewModel.swift
@@ -15,7 +15,7 @@ private typealias € = L10n.Scene.RestoreWallet
 
 /// Navigation from RestoreWallet
 enum RestoreWalletNavigation: TrackedUserAction {
-    case userInitiatedRestorationOfWallet(Wallet)
+    case restoreWallet(Wallet)
 }
 
 // MARK: - RestoreWalletViewModel
@@ -33,7 +33,10 @@ final class RestoreWalletViewModel: BaseViewModel<
     
     // swiftlint:disable:next function_body_length
     override func transform(input: Input) -> Output {
-        
+        func userIntends(to intention: Step) {
+            stepper.step(intention)
+        }
+
         let fromView = input.fromView
 
         let encryptionPassphraseMode: WalletEncryptionPassphrase.Mode = .restore
@@ -72,9 +75,7 @@ final class RestoreWalletViewModel: BaseViewModel<
         
         bag <~ [
             fromView.restoreTrigger
-                .withLatestFrom(wallet).do(onNext: { [unowned stepper] in
-                    stepper.step(.userInitiatedRestorationOfWallet($0))
-                })
+                .withLatestFrom(wallet).do(onNext: { userIntends(to: .restoreWallet($0)) })
                 .drive()
         ]
 

--- a/Source/Scenes/Onboarding/2_ChooseWallet/ChooseWalletCoordinator.swift
+++ b/Source/Scenes/Onboarding/2_ChooseWallet/ChooseWalletCoordinator.swift
@@ -37,10 +37,10 @@ private extension ChooseWalletCoordinator {
     }
 
     func toChooseWallet() {
-        present(type: ChooseWallet.self, viewModel: ChooseWalletViewModel()) { [unowned self] in
-            switch $0 {
-            case .userSelectedCreateNewWallet: self.toCreateNewWallet()
-            case .userSelectedRestoreWallet: self.toRestoreWallet()
+        present(type: ChooseWallet.self, viewModel: ChooseWalletViewModel()) { [unowned self] userIntendsTo in
+            switch userIntendsTo {
+            case .createNewWallet: self.toCreateNewWallet()
+            case .restoreWallet: self.toRestoreWallet()
             }
         }
     }

--- a/Source/Scenes/Onboarding/3_ChoosePincode/1_ChoosePincode/ChoosePincodeViewModel.swift
+++ b/Source/Scenes/Onboarding/3_ChoosePincode/1_ChoosePincode/ChoosePincodeViewModel.swift
@@ -10,13 +10,13 @@ import Foundation
 import RxCocoa
 import RxSwift
 
-enum ChoosePincodeNavigation: TrackedUserAction {
-    case userChoseUnconfirmedPincode(Pincode)
-    case userWannaSkipChoosingPincode
+enum ChoosePincodeUserAction: TrackedUserAction {
+    case chosePincode(Pincode)
+    case skip
 }
 
 final class ChoosePincodeViewModel: BaseViewModel<
-    ChoosePincodeNavigation,
+    ChoosePincodeUserAction,
     ChoosePincodeViewModel.InputFromView,
     ChoosePincodeViewModel.Output
 > {
@@ -28,11 +28,11 @@ final class ChoosePincodeViewModel: BaseViewModel<
         bag <~ [
             input.fromView.confirmedTrigger.withLatestFrom(pincode.filterNil())
             .do(onNext: { [unowned self] in
-                self.stepper.step(.userChoseUnconfirmedPincode($0))
+                self.stepper.step(.chosePincode($0))
             }).drive(),
 
             input.fromController.rightBarButtonTrigger.do(onNext: { [unowned stepper] in
-                stepper.step(.userWannaSkipChoosingPincode)
+                stepper.step(.skip)
             }).drive()
         ]
 

--- a/Source/Scenes/Onboarding/3_ChoosePincode/2_ConfirmNewPincode/ConfirmNewPincodeViewModel.swift
+++ b/Source/Scenes/Onboarding/3_ChoosePincode/2_ConfirmNewPincode/ConfirmNewPincodeViewModel.swift
@@ -10,13 +10,15 @@ import Foundation
 import RxCocoa
 import RxSwift
 
-enum ConfirmNewPincodeNavigation: String, TrackedUserAction {
-    case userFinishedChoosingPincode
-    case userWannaSkipChoosingPincode
+// MARK: - ConfirmNewPincodeUserAction
+enum ConfirmNewPincodeUserAction: TrackedUserAction {
+    case confirmPincode
+    case skip
 }
 
+// MARK: - ConfirmNewPincodeViewModel
 final class ConfirmNewPincodeViewModel: BaseViewModel<
-    ConfirmNewPincodeNavigation,
+    ConfirmNewPincodeUserAction,
     ConfirmNewPincodeViewModel.InputFromView,
     ConfirmNewPincodeViewModel.Output
 > {
@@ -41,11 +43,11 @@ final class ConfirmNewPincodeViewModel: BaseViewModel<
             input.fromView.confirmedTrigger.withLatestFrom(confirmedPincode.filterNil())
                 .do(onNext: { [unowned self] in
                 self.useCase.userChoose(pincode: $0)
-                self.stepper.step(.userFinishedChoosingPincode)
+                self.stepper.step(.confirmPincode)
             }).drive(),
 
             input.fromController.rightBarButtonTrigger.do(onNext: { [unowned stepper] in
-                stepper.step(.userWannaSkipChoosingPincode)
+                stepper.step(.skip)
             }).drive()
         ]
 

--- a/Source/Scenes/Onboarding/3_ChoosePincode/ManagePincodeCoordinator.swift
+++ b/Source/Scenes/Onboarding/3_ChoosePincode/ManagePincodeCoordinator.swift
@@ -48,9 +48,9 @@ private extension ManagePincodeCoordinator {
 
     func toConfirmExisting() {
         let viewModel = UnlockAppWithPincodeViewModel(useCase: useCase, userWantsToRemovePincode: intent.userWantsToRemovePincode)
-        present(type: UnlockAppWithPincode.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userAbortedRemovalOfPin, .userDidUnlockApp, .userRemovedPincode: self.finish()
+        present(type: UnlockAppWithPincode.self, viewModel: viewModel) { [unowned self] userDid in
+            switch userDid {
+            case .cancelPincodeRemoval, .unlockApp, .removePincode: self.finish()
             }
         }
     }
@@ -58,20 +58,20 @@ private extension ManagePincodeCoordinator {
     func toChoosePincode() {
         present(type: ChoosePincode.self, viewModel: ChoosePincodeViewModel(), configureNavigationItem: {
             $0.hidesBackButton = true
-        }, navigationHandler: { [unowned self] in
-            switch $0 {
-            case .userChoseUnconfirmedPincode(let unconfirmedPincode): self.toConfirmPincode(unconfirmedPincode: unconfirmedPincode)
-            case .userWannaSkipChoosingPincode: self.skipPincode()
+        }, navigationHandler: { [unowned self] userDid in
+            switch userDid {
+            case .chosePincode(let unconfirmedPincode): self.toConfirmPincode(unconfirmedPincode: unconfirmedPincode)
+            case .skip: self.skipPincode()
             }
         })
     }
 
     func toConfirmPincode(unconfirmedPincode: Pincode) {
         let viewModel = ConfirmNewPincodeViewModel(useCase: useCase, confirm: unconfirmedPincode)
-        present(type: ConfirmNewPincode.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userWannaSkipChoosingPincode: self.skipPincode()
-            case .userFinishedChoosingPincode: self.finish()
+        present(type: ConfirmNewPincode.self, viewModel: viewModel) { [unowned self] userDid in
+            switch userDid {
+            case .skip: self.skipPincode()
+            case .confirmPincode: self.finish()
             }
         }
     }

--- a/Source/Scenes/Onboarding/OnboardingCoordinator.swift
+++ b/Source/Scenes/Onboarding/OnboardingCoordinator.swift
@@ -55,9 +55,9 @@ private extension OnboardingCoordinator {
 
     func toTermsOfService() {
         let viewModel = TermsOfServiceViewModel(useCase: onboardingUseCase)
-        present(type: TermsOfService.self, viewModel: viewModel) { [unowned self] in
-            switch $0 {
-            case .userAcceptedTerms: self.toWarningERC20()
+        present(type: TermsOfService.self, viewModel: viewModel) { [unowned self] userDid in
+            switch userDid {
+            case .acceptTermsOfService: self.toWarningERC20()
             }
         }
     }
@@ -66,7 +66,7 @@ private extension OnboardingCoordinator {
         let viewModel = WarningERC20ViewModel(useCase: onboardingUseCase)
         present(type: WarningERC20.self, viewModel: viewModel) { [unowned self] in
             switch $0 {
-            case .userSelectedRisksAreUnderstood: self.toChooseWallet()
+            case .understandRisks: self.toChooseWallet()
             }
         }
     }


### PR DESCRIPTION
Now using shorter case names for UserActions (navigation from ViewModel), while also making the code base more readable in coordinator (by naming `userIntendsTo` and `userDid` as name on variable in NavigationHandler scope) and in the Viewmodel (by using `func userDid` and `func userIntends:to`)