### PR TITLE
fixed warning `Unbalanced calls to begin/end appearance transitions f…

### DIFF
--- a/Source/Application/AppCoordinator.swift
+++ b/Source/Application/AppCoordinator.swift
@@ -33,7 +33,7 @@ final class AppCoordinator: BaseCoordinator<AppCoordinator.NavigationStep> {
         super.init(navigationController: neverUsedNavigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         if walletUseCase.hasConfiguredWallet {
             toMain(lockIfNeeded: true)
         } else {
@@ -66,7 +66,6 @@ private extension AppCoordinator {
     }
 
     func toMain(lockIfNeeded lock: Bool = false) {
-        defer { if lock { lockApp() } }
         let navigationController = UINavigationController()
         window.rootViewController = navigationController
 
@@ -77,11 +76,13 @@ private extension AppCoordinator {
             deeplinkedTransaction: deepLinkHandler.navigation.map { $0.asTransaction }.filterNil()
         )
 
-        start(coordinator: main, transition: .replace) { [unowned self] userDid in
+        start(coordinator: main, transition: .replace, didStart: { [unowned self] in
+            if lock { self.lockApp() }
+        }, navigationHandler: { [unowned self] userDid in
             switch userDid {
             case .removeWallet: self.toOnboarding()
             }
-        }
+        })
     }
 
     func toUnlockAppWithPincodeIfNeeded() {

--- a/Source/Application/Navigation/Coordinator/AnyCoordinator.swift
+++ b/Source/Application/Navigation/Coordinator/AnyCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol AnyCoordinator: AnyObject, CustomStringConvertible {
     var childCoordinators: [AnyCoordinator] { get set }
-    func start()
+    func start(didStart: CoordinatorDidStart?)
     var navigationController: UINavigationController { get }
 }
 

--- a/Source/Scenes/0_Onboarding/2_ChooseWallet/1a_CreateNewWallet/CreateNewWalletCoordinator.swift
+++ b/Source/Scenes/0_Onboarding/2_ChooseWallet/1a_CreateNewWallet/CreateNewWalletCoordinator.swift
@@ -25,7 +25,7 @@ final class CreateNewWalletCoordinator: BaseCoordinator<CreateNewWalletCoordinat
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toCreateWallet()
     }
 }

--- a/Source/Scenes/0_Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletCoordinator.swift
+++ b/Source/Scenes/0_Onboarding/2_ChooseWallet/1b_RestoreWallet/RestoreWalletCoordinator.swift
@@ -21,7 +21,7 @@ final class RestoreWalletCoordinator: BaseCoordinator<RestoreWalletCoordinator.N
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toRestoreWallet()
     }
 }

--- a/Source/Scenes/0_Onboarding/2_ChooseWallet/ChooseWalletCoordinator.swift
+++ b/Source/Scenes/0_Onboarding/2_ChooseWallet/ChooseWalletCoordinator.swift
@@ -23,7 +23,7 @@ final class ChooseWalletCoordinator: BaseCoordinator<ChooseWalletCoordinator.Nav
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toChooseWallet()
     }
 }

--- a/Source/Scenes/0_Onboarding/4_ChoosePincode/SetPincodeCoordinator.swift
+++ b/Source/Scenes/0_Onboarding/4_ChoosePincode/SetPincodeCoordinator.swift
@@ -20,7 +20,7 @@ final class SetPincodeCoordinator: BaseCoordinator<SetPincodeCoordinator.Navigat
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         guard !useCase.hasConfiguredPincode else {
             incorrectImplementation("Changing a pincode is not supported, make changes in UI so that user need to remove wallet first, then present user with the option to set a (new) pincode.")
         }

--- a/Source/Scenes/0_Onboarding/OnboardingCoordinator.swift
+++ b/Source/Scenes/0_Onboarding/OnboardingCoordinator.swift
@@ -26,7 +26,7 @@ final class OnboardingCoordinator: BaseCoordinator<OnboardingCoordinator.Navigat
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toNextStep()
     }
 }

--- a/Source/Scenes/1_Main/1_Main/A_Send/SendCoordinator.swift
+++ b/Source/Scenes/1_Main/1_Main/A_Send/SendCoordinator.swift
@@ -26,7 +26,7 @@ final class SendCoordinator: BaseCoordinator<SendCoordinator.NavigationStep> {
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toPrepareTransaction()
     }
 }

--- a/Source/Scenes/1_Main/1_Main/B_Receive/ReceiveCoordinator.swift
+++ b/Source/Scenes/1_Main/1_Main/B_Receive/ReceiveCoordinator.swift
@@ -25,7 +25,7 @@ final class ReceiveCoordinator: BaseCoordinator<ReceiveCoordinator.NavigationSte
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toReceive()
     }
 }

--- a/Source/Scenes/1_Main/1_Main/C_Settings/SettingsCoordinator.swift
+++ b/Source/Scenes/1_Main/1_Main/C_Settings/SettingsCoordinator.swift
@@ -34,7 +34,7 @@ final class SettingsCoordinator: BaseCoordinator<SettingsCoordinator.NavigationS
         super.init(navigationController: navigationController)
     }
 
-    override func start() {
+    override func start(didStart: CoordinatorDidStart? = nil) {
         toSettings()
     }
 }

--- a/Source/Scenes/1_Main/MainCoordinator.swift
+++ b/Source/Scenes/1_Main/MainCoordinator.swift
@@ -32,8 +32,8 @@ final class MainCoordinator: BaseCoordinator<MainCoordinator.NavigationStep> {
         bag <~ deeplinkedTransaction.mapToVoid().do(onNext: { [unowned self] in self.toSendPrefilTransaction() }).drive()
     }
 
-    override func start() {
-        toMain()
+    override func start(didStart: CoordinatorDidStart? = nil) {
+        toMain(didStart: didStart)
     }
 }
 
@@ -51,14 +51,14 @@ private extension MainCoordinator {
 // MARK: - Navigation
 private extension MainCoordinator {
 
-    func toMain() {
+    func toMain(didStart: CoordinatorDidStart? = nil) {
 
         let viewModel = MainViewModel(
             transactionUseCase: useCaseProvider.makeTransactionsUseCase(),
             walletUseCase: useCaseProvider.makeWalletUseCase()
         )
 
-        push(scene: Main.self, viewModel: viewModel) { [unowned self] userIntendsTo, _ in
+        push(scene: Main.self, viewModel: viewModel, navigationPresentationCompletion: didStart) { [unowned self] userIntendsTo, _ in
             switch userIntendsTo {
             case .send: self.toSend()
             case .receive: self.toReceive()


### PR DESCRIPTION
…or <UINavigationController` that was caused by presenting the Unlock scene before navigation presentation of Main scene was finished (presented by MainCoordinator). The solution is to introduce a new closure, that we can pass into BaseCoordinator, being called ultimately by the Coordinator when the it finished pushing, replacing or presenting a ViewController.