### PR TITLE
Navigation removing all VC from NC stack when using `replace`

### DIFF
--- a/Source/Application/AppDelegate.swift
+++ b/Source/Application/AppDelegate.swift
@@ -26,7 +26,9 @@ class AppDelegate: UIResponder {
 
 extension AppDelegate: UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        appCoordinator.start()
+        defer {
+            appCoordinator.start()
+        }
         bootstrap()
         return true
     }

--- a/Source/Application/Navigation/Coordinator/BaseCoordinator.swift
+++ b/Source/Application/Navigation/Coordinator/BaseCoordinator.swift
@@ -23,7 +23,7 @@ class BaseCoordinator<NavigationStep>: Coordinating, Navigating {
     /// Dispose bag used for disposing of Disposables from navigation subscription of child coordinators navigation.
     let bag = DisposeBag()
 
-    private(set) var navigationController: UINavigationController
+    let navigationController: UINavigationController
 
     // MARK: - Initialization
     init(navigationController: UINavigationController) {

--- a/Source/Application/Navigation/Coordinator/Coordinating/Coordinating+Coordinator/Coordinating+Child+Start.swift
+++ b/Source/Application/Navigation/Coordinator/Coordinating/Coordinating+Coordinator/Coordinating+Child+Start.swift
@@ -35,16 +35,20 @@ extension Coordinating {
         navigationHandler: @escaping (_ step: C.NavigationStep) -> Void
         ) where C: Coordinating & Navigating {
 
+        // Start the child coordinator (which is responsible for setting up its root UIViewController and presenting it)
+        // and pass along the `didStart` closure, which the child should invoke or delegate to invoke.
+        let startChild = { [unowned child] in
+            child.start(didStart: didStart)
+        }
+
         // Add the child coordinator to the childCoordinator array
         switch transition {
         case .replace:
             childCoordinators = [child]
-            navigationController.removeAllViewControllers { [unowned child] in
-                child.start(didStart: didStart)
-            }
+            navigationController.removeAllViewControllers { startChild() }
         case .append:
             childCoordinators.append(child)
-            child.start(didStart: didStart)
+            startChild()
         }
 
         // Subscribe to the navigation steps emitted by the child coordinator


### PR DESCRIPTION
This PR fixes a bug where navigation stack was not properly updated when using `replace`